### PR TITLE
Restart server and auto refresh browser on changes!

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This will download a webpage which makes several requests from data from the mod
 
 For more information on how the Router works and the structure of model.json, see the Router source at https://github.com/Netflix/falcor-router-demo.
 
---------------
+
 [1]: https://www.npmjs.com/package/gulp-nodemon    "gulp-nodemon"
 [2]: https://www.npmjs.com/package/browser-sync    "browser-sync"
---------------

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This will download a webpage which makes several requests from data from the mod
 
 For more information on how the Router works and the structure of model.json, see the Router source at https://github.com/Netflix/falcor-router-demo.
 
-
-[1]: https://www.npmjs.com/package/gulp-nodemon    gulp-nodemon
-[2]: https://www.npmjs.com/package/browser-sync    browser-sync
+--------------
+[1]: https://www.npmjs.com/package/gulp-nodemon    "gulp-nodemon"
+[2]: https://www.npmjs.com/package/browser-sync    "browser-sync"
+--------------

--- a/README.md
+++ b/README.md
@@ -8,9 +8,21 @@ This project is a demonstration of how to create a stateless Virtual JSON Graph 
 clone repo
 npm install
 npm start
-open your browser and visit http://localhost:9090
+Automatically opens default browser with url http://localhost:9090
 ```
+
+## Notes
+
+No manual refresh of browser on every change of html file.
+
+1. On every change of html file browser gets reloaded using [browser-sync][2].
+1. On every change of index.js, server gets restarted using [gulp-nodemon][1].
+
 
 This will download a webpage which makes several requests from data from the model.json resource on the application server, and prints the results to the console.  You will not see anything on your screen until you open up the developer console. Checkout the source of the website to see what types of operations can be performed on the model.json file on the server.
 
 For more information on how the Router works and the structure of model.json, see the Router source at https://github.com/Netflix/falcor-router-demo.
+
+
+[1]: https://www.npmjs.com/package/gulp-nodemon    gulp-nodemon
+[2]: https://www.npmjs.com/package/browser-sync    browser-sync

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var gulp = require('gulp');
+var browserSync = require('browser-sync');
+var nodemon = require('gulp-nodemon');
+
+/*
+ * Gulp default task
+ */
+gulp.task('default', ['browser-sync'], function(){
+
+});
+
+gulp.task('browser-sync', ['nodemon'], function(){
+	browserSync.init(null, {
+		proxy: 'http://localhost:9091',
+		files: ['*.html'],
+		browser: "google chrome",
+		port: 9090
+	});
+});
+
+gulp.task('nodemon', function(cb){
+	var started = false;
+
+	return nodemon({
+		script: 'index.js'
+	}).on('start', function(){
+		if(!started){
+			cb();
+			started = true;
+		}
+	});
+});

--- a/index.js
+++ b/index.js
@@ -15,10 +15,9 @@ app.use('/model.json', FalcorServer.dataSourceRoute(function(req, res) {
 
 app.use(express.static('.'));
 
-var server = app.listen(9090, function(err) {
+var server = app.listen(9091, function(err) {
     if (err) {
         console.error(err);
         return;
     }
-    console.log("navigate to http://localhost:9090");
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "scripts": {
-    "start": "node index.js"
+    "start": "gulp"
   },
   "dependencies": {
     "express": "~4.11.1",
@@ -27,6 +27,9 @@
     "falcor-express": "0.1.1"
   },
   "devDependencies": {
-    "eslint": "^0.21.0"
+    "browser-sync": "^2.8.2",
+    "eslint": "^0.21.0",
+    "gulp": "^3.9.0",
+    "gulp-nodemon": "^2.0.4"
   }
 }


### PR DESCRIPTION
## Restart server and auto refresh browser on changes!

No manual refresh of browser on changing html files. No need to restart server on changing `index.js`.
Added few dev dependencies for this feature `gulp`, `browser-sync` and `gulp-nodemon`.
## npm start

``` shell
[samar@sp falcor-express-demo [±] watch_reload 8b4db6f ✗]$ npm start

> falcor-express-demo@0.0.1 start /Users/samar/Projects/falcor-express-demo
> gulp

[11:43:17] Using gulpfile ~/Projects/falcor-express-demo/gulpfile.js
[11:43:17] Starting 'nodemon'...
[11:43:17] [nodemon] v1.4.1
[11:43:17] [nodemon] to restart at any time, enter `rs`
[11:43:17] [nodemon] watching: *.*
[11:43:17] [nodemon] starting `node index.js`
[11:43:17] Finished 'nodemon' after 193 ms
[11:43:17] Starting 'browser-sync'...
[11:43:20] Finished 'browser-sync' after 2.3 s
[11:43:20] Starting 'default'...
[11:43:20] Finished 'default' after 14 μs
[BS] Proxying: http://localhost:9091
[BS] Access URLs:
 ---------------------------------------
       Local: http://localhost:9090
    External: http://192.168.31.130:9090
 ---------------------------------------
          UI: http://localhost:3001
 UI External: http://192.168.31.130:3001
 ---------------------------------------
[BS] Watching files...
[BS] File changed: index.html
[BS] File changed: index.html
[11:44:41] [nodemon] restarting due to changes...
[11:44:42] [nodemon] starting `node index.js`
```
