### PR TITLE
Upgrade NPM dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "express": "~4.11.1",
-    "body-parser": "^1.12.4",
-    "falcor-router-demo": "1.0.3",
-    "falcor-express": "0.1.1"
+    "express": "^4.13.3",
+    "body-parser": "^1.14.1",
+    "falcor-router-demo": "^1.0.4",
+    "falcor-express": "^0.1.2"
   },
   "devDependencies": {
-    "eslint": "^0.21.0"
+    "eslint": "^1.7.1"
   }
 }


### PR DESCRIPTION
Fixes issues running the demo under Node 4. As the falcor-router-demo
repository was bumped to 1.0.4, I'm guessing this project was just not
updated.

If you'd like me to restrict the dependency update to just falcor-router-demo, I can do that as well.
